### PR TITLE
Add Bluemix SSO info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,6 @@ lm.emit_log(
 # Where do I find my token?
 
 Find your logging token and space ID by running `python get_token.py` and
-following the prompts.
+following the prompts. If you log into Bluemix using an SSO, use `apikey`
+as your username and a [Bluemix API Key](https://console.bluemix.net/iam/#/apikeys)
+as the password, when prompted.


### PR DESCRIPTION
It took some time to track down the info on how to get a logging token
as an SSO user. Having this info in the README would have saved me
some time.